### PR TITLE
give ev default value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,6 @@ export default async function (manager: Manager, settings: ComponentSettings) {
   })
 
   manager.addEventListener('pageview', event => {
-    const eventType = event.payload.ev || 'PAGE_VIEW'
-    handler("PAGE_VIEW", event, settings)
+    handler('PAGE_VIEW', event, settings)
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export default async function (manager: Manager, settings: ComponentSettings) {
   })
 
   manager.addEventListener('pageview', event => {
-    const eventType = event.payload.ev
+    const eventType = event.payload.ev || 'PAGE_VIEW'
     handler(eventType, event, settings)
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,6 @@ export default async function (manager: Manager, settings: ComponentSettings) {
 
   manager.addEventListener('pageview', event => {
     const eventType = event.payload.ev || 'PAGE_VIEW'
-    handler(eventType, event, settings)
+    handler("PAGE_VIEW", event, settings)
   })
 }


### PR DESCRIPTION
pageview event (unless it is default event created when setting up the tool) doesn't have `ev` field, thus we need to provide a default value